### PR TITLE
feat!: v2.0.0 — flat config support, fix no-eval false positives, add autofix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,5 +18,7 @@ jobs:
                   node-version: '22'
             - name: Install dependencies
               run: npm install
+            - name: Run lint
+              run: npm run lint
             - name: Run tests
               run: npm run test

--- a/README.md
+++ b/README.md
@@ -1,51 +1,106 @@
 # @andreasnicolaou/eslint-plugin-conditional-best-practices
 
-This ESLint plugin includes several opinionated rules aimed at enhancing the readability, performance, and maintainability of conditionals in JavaScript.
+Opinionated ESLint rules for **cleaner, safer conditionals** — limit nesting, prefer early returns, catch duplicate and constant conditions, simplify ternaries, and flag risky `eval`.
 
-These rules focus on writing clear and efficient conditional statements, so while they encourage consistency and simplicity, they may not suit every coding style. Feel free to adjust the rules based on your team's preferences.
+[![GitHub Workflow Status (with event)](https://img.shields.io/github/actions/workflow/status/andreasnicolaou/eslint-plugin-conditional-best-practices/build.yaml)](https://github.com/andreasnicolaou/eslint-plugin-conditional-best-practices/actions/workflows/build.yaml)
+![NPM Version](https://img.shields.io/npm/v/%40andreasnicolaou%2Feslint-plugin-conditional-best-practices)
+![NPM Downloads](https://img.shields.io/npm/dm/%40andreasnicolaou%2Feslint-plugin-conditional-best-practices)
+![NPM License](https://img.shields.io/npm/l/%40andreasnicolaou%2Feslint-plugin-conditional-best-practices)
 
-# Installation
+> Zero runtime dependencies. Works with ESLint **flat config** (ESLint 9, and 8.21+) and legacy `.eslintrc`.
 
-Install the npm package
+These rules focus on writing clear and efficient conditional statements. They are intentionally opinionated, so feel free to enable only the ones that suit your team.
+
+## Installation
 
 ```bash
-# If eslint is installed globally
-npm install -g @andreasnicolaou/eslint-plugin-conditional-best-practices
-
-# If eslint is installed locally
 npm install -D @andreasnicolaou/eslint-plugin-conditional-best-practices
 ```
 
-To use this plugin in your project, add it to your ESLint configuration like this:
+## Usage
+
+### Flat config (`eslint.config.js`) — ESLint 9+ (recommended)
+
+The quickest way is to extend the bundled `recommended` config, which registers the plugin and turns on every rule at sensible severities:
 
 ```js
-{
-  "plugins": ["@andreasnicolaou/conditional-best-practices"],
-  "extends": [
-    "plugin:@andreasnicolaou/conditional-best-practices/recommended"
-  ]
-}
+// eslint.config.js
+import conditional from '@andreasnicolaou/eslint-plugin-conditional-best-practices';
 
+export default [conditional.configs.recommended];
 ```
 
-- Alternatively, you can extend individual rules if you prefer more granular control.
+Prefer granular control? Register the plugin and pick rules yourself:
 
-# Usage
+```js
+// eslint.config.js
+import conditional from '@andreasnicolaou/eslint-plugin-conditional-best-practices';
 
-This plugin enforces the following opinionated best practices:
+export default [
+    {
+        plugins: {
+            '@andreasnicolaou/conditional-best-practices': conditional,
+        },
+        rules: {
+            '@andreasnicolaou/conditional-best-practices/no-eval': 'error',
+            '@andreasnicolaou/conditional-best-practices/no-excessive-nested-conditionals': ['warn', { max: 3 }],
+            '@andreasnicolaou/conditional-best-practices/prefer-early-return': 'warn',
+        },
+    },
+];
+```
 
-| Name                                                                         | Description                                                                                 |
-| :--------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------ |
-| [no-constant-conditionals](docs/no-constant-conditionals.md)                 | This rule disallows conditionals that always evaluate to true or false.                     |
-| [no-duplicated-conditions](docs/no-duplicated-conditions.md)                 | This rule disallows duplicate conditions in if-else chains.                                 |
-| [no-excessive-nested-conditionals](docs/no-excessive-nested-conditionals.md) | This rule disallows excessive nesting of conditionals in order to improve code readability. |
-| [no-long-else-if-chains](docs/no-long-else-if-chains.md)                     | This rule limits the number of consecutive else-if statements.                              |
-| [no-nested-ternary-operators](docs/no-nested-ternary-operators.md)           | This rule disallows nested ternary operators.                                               |
-| [no-useless-ternary](docs/no-useless-ternary.md)                             | This rule disallows unnecessary ternary expressions.                                        |
-| [prefer-early-return](docs/prefer-early-return.md)                           | This rule encourages the use of early returns instead of deeply nested if-else blocks.      |
-| [require-default-in-switch](docs/require-default-in-switch.md)               | This rule ensures that switch statements include a default case and/or its not empty.       |
-| [no-eval](docs/no-eval.md)                                                   | This rule disallows the use of eval() due to security risks.                                |
+CommonJS works the same way with `require`:
 
-# Autofixing
+```js
+const conditional = require('@andreasnicolaou/eslint-plugin-conditional-best-practices');
+module.exports = [conditional.configs.recommended];
+```
 
-Currently, this plugin does not support automatic fixes for code violations. It only detects incorrect usage and warns you, helping to maintain consistency and best practices in your codebase.
+There is also a `conditional.configs.all` config that enables **every** rule as an `error`.
+
+### Legacy config (`.eslintrc`)
+
+```jsonc
+{
+    "plugins": ["@andreasnicolaou/conditional-best-practices"],
+    "extends": ["plugin:@andreasnicolaou/conditional-best-practices/legacy-recommended"],
+}
+```
+
+## Rules
+
+✅ = enabled in `recommended` · 🔧 = autofixable · 💡 = has editor suggestions
+
+| Name                                                                         | Description                                                          | Recommended | Fixable |
+| :--------------------------------------------------------------------------- | :------------------------------------------------------------------- | :---------: | :-----: |
+| [no-constant-conditionals](docs/no-constant-conditionals.md)                 | Disallow conditionals that always evaluate to true or false.         |     ✅      |         |
+| [no-duplicated-conditions](docs/no-duplicated-conditions.md)                 | Disallow duplicate conditions in `if`/`else if` chains.              |     ✅      |         |
+| [no-excessive-nested-conditionals](docs/no-excessive-nested-conditionals.md) | Disallow excessive nesting of conditionals (configurable `max`).     |     ✅      |         |
+| [no-long-else-if-chains](docs/no-long-else-if-chains.md)                     | Limit the number of consecutive `else if` statements (configurable). |     ✅      |         |
+| [no-nested-ternary-operators](docs/no-nested-ternary-operators.md)           | Disallow nested ternary operators.                                   |     ✅      |         |
+| [no-useless-ternary](docs/no-useless-ternary.md)                             | Disallow unnecessary boolean ternaries (`x ? true : false`).         |     ✅      |   🔧    |
+| [prefer-early-return](docs/prefer-early-return.md)                           | Encourage early returns instead of deeply nested `if`/`else` blocks. |     ✅      |         |
+| [require-default-in-switch](docs/require-default-in-switch.md)               | Require a non-empty `default` case in `switch` statements.           |     ✅      |   💡    |
+| [no-eval](docs/no-eval.md)                                                   | Disallow `eval()` and the `Function` constructor (security risk).    |     ✅      |         |
+
+## Autofixing
+
+Run ESLint with `--fix` to apply automatic fixes:
+
+```bash
+npx eslint . --fix
+```
+
+- **`no-useless-ternary`** rewrites `cond ? true : false` → `cond` and `cond ? false : true` → `!cond`.
+- **`require-default-in-switch`** offers an editor suggestion to insert a `default` case (suggestions are applied manually from your editor, not by `--fix`).
+
+The remaining rules report problems without auto-rewriting, since the safe fix depends on intent.
+
+## Contributing
+
+Issues and pull requests are welcome at the [GitHub repository](https://github.com/andreasnicolaou/eslint-plugin-conditional-best-practices).
+
+## License
+
+[MIT](LICENSE) © Andreas Nicolaou

--- a/docs/no-duplicated-conditions.md
+++ b/docs/no-duplicated-conditions.md
@@ -2,7 +2,9 @@
 
 ## Description
 
-This rule disallows duplicate conditions in if-else chains.
+This rule disallows duplicate conditions in `if`/`else if` chains. A repeated condition is always dead code: the second branch can never run, which usually signals a copy-paste mistake.
+
+It compares the full source text of each condition, so it catches more than bare identifiers — for example `if (a > b) {} else if (a > b) {}` is reported too.
 
 ## Options
 
@@ -23,10 +25,22 @@ if (a) {
 }
 ```
 
+```js
+if (a > b) {
+} else if (a > b) {
+}
+```
+
 ### **Valid** 👍
 
 ```js
 if (a) {
 } else if (b) {
+}
+```
+
+```js
+if (a > b) {
+} else if (a < b) {
 }
 ```

--- a/docs/no-eval.md
+++ b/docs/no-eval.md
@@ -2,7 +2,16 @@
 
 ## Description
 
-Disallow use of eval() due to security risks.
+Disallow use of `eval()` and the `Function` constructor due to security and performance risks. Both can execute arbitrary strings as code, which opens the door to injection attacks and prevents engine optimization.
+
+The rule detects:
+
+- Direct calls: `eval(...)`
+- Indirect/aliased eval: `const run = eval;`
+- Global access: `window.eval(...)`, `globalThis['eval'](...)`, `self.eval`, `global.eval`
+- The implied eval of `new Function(...)`
+
+It does **not** flag identifiers or strings that merely contain the substring `eval` (for example `"retrieval"`, `evaluate()`, or `obj.eval` on a non-global object).
 
 ## Options
 
@@ -18,23 +27,31 @@ This rule does not accept any options.
 ### **Invalid** 👎
 
 ```js
-eval(console.log('Hi'));
+eval('console.log("Hi")');
 ```
 
 ```js
-window['eval'](console.log('Not Allowed'));
+window['eval']('1 + 1');
 ```
 
 ```js
-globalThis['eval'](console.log('Not Allowed'));
+globalThis.eval('1 + 1');
 ```
 
 ```js
 const exec = eval;
-exec(console.log('Not Allowed'));
+exec('alert(1)');
 ```
 
 ```js
-const safeEval = eval;
-safeEval(console.log('Not Allowed'));
+const fn = new Function('return 1');
+```
+
+### **Valid** 👍
+
+```js
+const url = 'https://example.com/retrieval';
+const word = 'medieval';
+function evaluate() {}
+const handler = obj.eval; // `obj` is not a global object
 ```

--- a/docs/no-eval.md
+++ b/docs/no-eval.md
@@ -7,7 +7,8 @@ Disallow use of `eval()` and the `Function` constructor due to security and perf
 The rule detects:
 
 - Direct calls: `eval(...)`
-- Indirect/aliased eval: `const run = eval;`
+- Indirect calls: `(0, eval)(...)`, `eval.call(...)`, `eval.apply(...)`
+- Aliased eval: `const run = eval;`
 - Global access: `window.eval(...)`, `globalThis['eval'](...)`, `self.eval`, `global.eval`
 - The implied eval of `new Function(...)`
 

--- a/docs/no-useless-ternary.md
+++ b/docs/no-useless-ternary.md
@@ -2,7 +2,12 @@
 
 ## Description
 
-This rule disallows unnecessary ternary expressions.
+This rule disallows unnecessary ternary expressions where both branches are boolean literals, such as `cond ? true : false`.
+
+This rule is **autofixable** with `eslint --fix`:
+
+- `cond ? true : false` → `cond`
+- `cond ? false : true` → `!cond`
 
 ## Options
 
@@ -12,6 +17,7 @@ This rule does not accept any options.
 
 - Type: Suggestion
 - Recommended: Yes
+- Fixable: Yes (code)
 
 ## Examples
 

--- a/docs/prefer-early-return.md
+++ b/docs/prefer-early-return.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-This rule encourages the use of early returns instead of deeply nested if-else blocks.
+This rule encourages the use of early returns instead of deeply nested if-else blocks. It flags an `else` branch whose only statement is a `return`, whether written as a block (`else { return; }`) or inline (`else return;`).
 
 ## Options
 
@@ -24,6 +24,13 @@ function check(x) {
     } else {
         return;
     }
+}
+```
+
+```js
+function check(x) {
+    if (x) helloWorld();
+    else return;
 }
 ```
 

--- a/docs/require-default-in-switch.md
+++ b/docs/require-default-in-switch.md
@@ -2,7 +2,9 @@
 
 ## Description
 
-This rule ensures that switch statements include a default case and/or its not empty.
+This rule ensures that `switch` statements include a `default` case and that the `default` case is not empty.
+
+When the `default` case is missing, the rule offers an editor **suggestion** to insert one (`default: break;`). Suggestions are applied manually from your editor and are not run by `eslint --fix`.
 
 ## Options
 
@@ -12,6 +14,7 @@ This rule does not accept any options.
 
 - Type: Suggestion
 - Recommended: Yes
+- Has suggestions: Yes
 
 ## Examples
 

--- a/index.js
+++ b/index.js
@@ -1,21 +1,54 @@
 'use strict';
-const rules = require('./lib/rules');
 
-module.exports = {
-    rules,
-    configs: {
-        recommended: {
-            rules: {
-                '@andreasnicolaou/conditional-best-practices/no-excessive-nested-conditionals': 'warn',
-                '@andreasnicolaou/conditional-best-practices/no-long-else-if-chains': 'warn',
-                '@andreasnicolaou/conditional-best-practices/require-default-in-switch': 'warn',
-                '@andreasnicolaou/conditional-best-practices/no-constant-conditionals': 'error',
-                '@andreasnicolaou/conditional-best-practices/prefer-early-return': 'warn',
-                '@andreasnicolaou/conditional-best-practices/no-duplicated-conditions': 'error',
-                '@andreasnicolaou/conditional-best-practices/no-useless-ternary': 'warn',
-                '@andreasnicolaou/conditional-best-practices/no-nested-ternary-operators': 'warn',
-                '@andreasnicolaou/conditional-best-practices/no-eval': 'error',
-            },
-        },
-    },
+const rules = require('./lib/rules');
+const { name, version } = require('./package.json');
+
+const PLUGIN_NAME = '@andreasnicolaou/conditional-best-practices';
+
+// Severities used by the `recommended` config.
+const RECOMMENDED_SEVERITIES = {
+    'no-excessive-nested-conditionals': 'warn',
+    'no-long-else-if-chains': 'warn',
+    'require-default-in-switch': 'warn',
+    'no-constant-conditionals': 'error',
+    'prefer-early-return': 'warn',
+    'no-duplicated-conditions': 'error',
+    'no-useless-ternary': 'warn',
+    'no-nested-ternary-operators': 'warn',
+    'no-eval': 'error',
 };
+
+const prefixRules = (severityByRule) =>
+    Object.fromEntries(
+        Object.entries(severityByRule).map(([ruleName, severity]) => [`${PLUGIN_NAME}/${ruleName}`, severity])
+    );
+
+const recommendedRules = prefixRules(RECOMMENDED_SEVERITIES);
+const allRules = prefixRules(Object.fromEntries(Object.keys(rules).map((ruleName) => [ruleName, 'error'])));
+
+const plugin = {
+    meta: { name, version },
+    rules,
+    configs: {},
+};
+
+// Flat config (ESLint 9+). This is the default and recommended way to consume the plugin.
+plugin.configs.recommended = {
+    name: `${PLUGIN_NAME}/recommended`,
+    plugins: { [PLUGIN_NAME]: plugin },
+    rules: recommendedRules,
+};
+
+plugin.configs.all = {
+    name: `${PLUGIN_NAME}/all`,
+    plugins: { [PLUGIN_NAME]: plugin },
+    rules: allRules,
+};
+
+// Legacy config (.eslintrc / eslintrc-style via FlatCompat) for older setups.
+plugin.configs['legacy-recommended'] = {
+    plugins: [PLUGIN_NAME],
+    rules: recommendedRules,
+};
+
+module.exports = plugin;

--- a/lib/rules/no-constant-conditionals.js
+++ b/lib/rules/no-constant-conditionals.js
@@ -3,14 +3,12 @@
  * @author Andreas Nicolaou
  */
 'use strict';
-const utils = require('@typescript-eslint/utils');
 module.exports = {
     create: (context) => ({
         IfStatement(node) {
             if (
-                node.test.type === utils.AST_NODE_TYPES.Literal ||
-                (node.test.type === utils.AST_NODE_TYPES.UnaryExpression &&
-                    node.test.argument.type === utils.AST_NODE_TYPES.Literal)
+                node.test.type === 'Literal' ||
+                (node.test.type === 'UnaryExpression' && node.test.argument.type === 'Literal')
             ) {
                 context.report({
                     node: node.test,
@@ -24,6 +22,7 @@ module.exports = {
         docs: {
             description: 'Disallow conditionals that always evaluate to true or false.',
             recommended: true,
+            url: 'https://github.com/andreasnicolaou/eslint-plugin-conditional-best-practices/blob/main/docs/no-constant-conditionals.md',
         },
         messages: {
             constant: 'Avoid using constant conditions in if statements.',

--- a/lib/rules/no-duplicated-conditions.js
+++ b/lib/rules/no-duplicated-conditions.js
@@ -11,7 +11,7 @@ module.exports = {
             if (node.parent && node.parent.type === 'IfStatement' && node.parent.alternate === node) {
                 return;
             }
-            const sourceCode = context.sourceCode;
+            const sourceCode = context.sourceCode || context.getSourceCode();
             const seenConditions = new Set();
             const checkConditions = (statement) => {
                 if (statement.test) {

--- a/lib/rules/no-duplicated-conditions.js
+++ b/lib/rules/no-duplicated-conditions.js
@@ -3,29 +3,29 @@
  * @author Andreas Nicolaou
  */
 'use strict';
-const utils = require('@typescript-eslint/utils');
 module.exports = {
     create: (context) => ({
         IfStatement(node) {
-            const seenConditions = new Set([]);
+            // Only start from the head of a chain; nested `else if` nodes are
+            // visited as the `alternate` of their parent below.
+            if (node.parent && node.parent.type === 'IfStatement' && node.parent.alternate === node) {
+                return;
+            }
+            const sourceCode = context.sourceCode;
+            const seenConditions = new Set();
             const checkConditions = (statement) => {
                 if (statement.test) {
-                    if (
-                        statement.test.type === utils.AST_NODE_TYPES.Identifier ||
-                        statement.test.type === utils.AST_NODE_TYPES.Literal
-                    ) {
-                        const sourceCode = context.sourceCode.getText(statement.test);
-                        if (seenConditions.has(sourceCode)) {
-                            context.report({
-                                node: statement.test,
-                                messageId: 'duplicate',
-                            });
-                        } else {
-                            seenConditions.add(sourceCode);
-                        }
+                    const text = sourceCode.getText(statement.test);
+                    if (seenConditions.has(text)) {
+                        context.report({
+                            node: statement.test,
+                            messageId: 'duplicate',
+                        });
+                    } else {
+                        seenConditions.add(text);
                     }
                 }
-                if (statement.alternate && statement.alternate.type === utils.AST_NODE_TYPES.IfStatement) {
+                if (statement.alternate && statement.alternate.type === 'IfStatement') {
                     checkConditions(statement.alternate);
                 }
             };
@@ -37,6 +37,7 @@ module.exports = {
         docs: {
             description: 'Disallow duplicate conditions in if-else chains.',
             recommended: true,
+            url: 'https://github.com/andreasnicolaou/eslint-plugin-conditional-best-practices/blob/main/docs/no-duplicated-conditions.md',
         },
         messages: {
             duplicate: 'This condition is repeated in the if-else chain.',

--- a/lib/rules/no-eval.js
+++ b/lib/rules/no-eval.js
@@ -27,10 +27,32 @@ function isGlobalEvalMember(node) {
 
 module.exports = {
     create: (context) => ({
-        // Direct call: eval('...')
+        // Direct call: eval('...'), indirect call: (0, eval)('...'),
+        // and reflective call: eval.call(null, '...') / eval.apply(...)
         CallExpression(node) {
-            if (node.callee.type === 'Identifier' && node.callee.name === 'eval') {
+            const callee = node.callee;
+            // eval('...')
+            if (callee.type === 'Identifier' && callee.name === 'eval') {
                 context.report({ node, messageId: 'noEval' });
+                return;
+            }
+            // eval.call(...) / eval.apply(...)
+            if (
+                callee.type === 'MemberExpression' &&
+                callee.object.type === 'Identifier' &&
+                callee.object.name === 'eval' &&
+                callee.property.type === 'Identifier' &&
+                (callee.property.name === 'call' || callee.property.name === 'apply')
+            ) {
+                context.report({ node, messageId: 'noEval' });
+                return;
+            }
+            // (0, eval)('...') — the comma operator yields a reference to eval
+            if (callee.type === 'SequenceExpression') {
+                const last = callee.expressions[callee.expressions.length - 1];
+                if (last && last.type === 'Identifier' && last.name === 'eval') {
+                    context.report({ node, messageId: 'noEval' });
+                }
             }
         },
         // Implied eval: new Function('...')

--- a/lib/rules/no-eval.js
+++ b/lib/rules/no-eval.js
@@ -1,46 +1,54 @@
 /**
- * @fileoverview Disallow use of eval() due to security risks.
+ * @fileoverview Disallow use of eval() and the implied eval of `new Function()` due to security risks.
  * @author Andreas Nicolaou
  */
 'use strict';
-const utils = require('@typescript-eslint/utils');
+
+const GLOBAL_OBJECTS = new Set(['window', 'globalThis', 'global', 'self']);
+
+/**
+ * Returns true when the member expression references `<global>.eval`,
+ * covering both dot (`window.eval`) and computed (`window['eval']`) access.
+ * @param {object} node MemberExpression node
+ * @returns {boolean}
+ */
+function isGlobalEvalMember(node) {
+    if (node.object.type !== 'Identifier' || !GLOBAL_OBJECTS.has(node.object.name)) {
+        return false;
+    }
+    if (!node.computed && node.property.type === 'Identifier') {
+        return node.property.name === 'eval';
+    }
+    if (node.computed && node.property.type === 'Literal') {
+        return node.property.value === 'eval';
+    }
+    return false;
+}
+
 module.exports = {
     create: (context) => ({
-        Literal(node) {
-            if (typeof node.value === 'string' && node.value.includes('eval')) {
-                context.report({
-                    node,
-                    messageId: 'noEval',
-                });
-            }
-        },
+        // Direct call: eval('...')
         CallExpression(node) {
-            if (node.callee.type === utils.AST_NODE_TYPES.Identifier && node.callee.name === 'eval') {
-                context.report({
-                    node,
-                    messageId: 'noEval',
-                });
+            if (node.callee.type === 'Identifier' && node.callee.name === 'eval') {
+                context.report({ node, messageId: 'noEval' });
             }
         },
+        // Implied eval: new Function('...')
+        NewExpression(node) {
+            if (node.callee.type === 'Identifier' && node.callee.name === 'Function') {
+                context.report({ node, messageId: 'noFunction' });
+            }
+        },
+        // Indirect eval via aliasing: const run = eval;
         VariableDeclarator(node) {
-            if (node.init && node.init.type === utils.AST_NODE_TYPES.Identifier && node.init.name === 'eval') {
-                context.report({
-                    node,
-                    messageId: 'noEval',
-                });
+            if (node.init && node.init.type === 'Identifier' && node.init.name === 'eval') {
+                context.report({ node, messageId: 'noEval' });
             }
         },
+        // Global access: window.eval / globalThis['eval'] / self.eval ...
         MemberExpression(node) {
-            if (
-                node.object.type === utils.AST_NODE_TYPES.Identifier &&
-                ['window', 'globalThis'].includes(node.object.name) &&
-                node.property.type === utils.AST_NODE_TYPES.Identifier &&
-                node.property.name === 'eval'
-            ) {
-                context.report({
-                    node,
-                    messageId: 'noEval',
-                });
+            if (isGlobalEvalMember(node)) {
+                context.report({ node, messageId: 'noEval' });
             }
         },
     }),
@@ -49,9 +57,11 @@ module.exports = {
         docs: {
             description: 'Disallow use of eval() due to security risks',
             recommended: true,
+            url: 'https://github.com/andreasnicolaou/eslint-plugin-conditional-best-practices/blob/main/docs/no-eval.md',
         },
         messages: {
             noEval: 'Using eval() is a security risk and should be avoided.',
+            noFunction: 'The Function constructor is eval-like and should be avoided.',
         },
         schema: [],
     },

--- a/lib/rules/no-excessive-nested-conditionals.js
+++ b/lib/rules/no-excessive-nested-conditionals.js
@@ -3,7 +3,6 @@
  * @author Andreas Nicolaou
  */
 'use strict';
-const utils = require('@typescript-eslint/utils');
 module.exports = {
     create: (context) => ({
         IfStatement(node) {
@@ -19,21 +18,21 @@ module.exports = {
                     return;
                 }
                 // Check the body inside an if-statement block
-                if (node.consequent?.type === utils.AST_NODE_TYPES.BlockStatement) {
+                if (node.consequent?.type === 'BlockStatement') {
                     for (const stmt of node.consequent.body) {
-                        if (stmt.type === utils.AST_NODE_TYPES.IfStatement) {
+                        if (stmt.type === 'IfStatement') {
                             checkDepth(stmt, depth + 1);
                         }
                     }
-                } else if (node.consequent?.type === utils.AST_NODE_TYPES.IfStatement) {
+                } else if (node.consequent?.type === 'IfStatement') {
                     checkDepth(node.consequent, depth + 1);
                 }
                 // `else if` statements should be at the same depth
-                if (node.alternate?.type === utils.AST_NODE_TYPES.IfStatement) {
+                if (node.alternate?.type === 'IfStatement') {
                     checkDepth(node.alternate, depth);
-                } else if (node.alternate?.type === utils.AST_NODE_TYPES.BlockStatement) {
+                } else if (node.alternate?.type === 'BlockStatement') {
                     for (const stmt of node.alternate.body) {
-                        if (stmt.type === utils.AST_NODE_TYPES.IfStatement) {
+                        if (stmt.type === 'IfStatement') {
                             checkDepth(stmt, depth + 1);
                         }
                     }
@@ -47,6 +46,7 @@ module.exports = {
         docs: {
             description: 'Disallow excessive nested conditionals to improve readability',
             recommended: true,
+            url: 'https://github.com/andreasnicolaou/eslint-plugin-conditional-best-practices/blob/main/docs/no-excessive-nested-conditionals.md',
         },
         messages: {
             deep: 'Avoid nesting conditionals deeper than {{max}} levels.',

--- a/lib/rules/no-long-else-if-chains.js
+++ b/lib/rules/no-long-else-if-chains.js
@@ -3,7 +3,6 @@
  * @author Andreas Nicolaou
  */
 'use strict';
-const utils = require('@typescript-eslint/utils');
 module.exports = {
     create: (context) => ({
         IfStatement(node) {
@@ -13,7 +12,7 @@ module.exports = {
                 let count = 0;
                 let current = node;
                 // Traverse the `if-else if` chain and count the else-if statements
-                while (current.alternate && current.alternate.type === utils.AST_NODE_TYPES.IfStatement) {
+                while (current.alternate && current.alternate.type === 'IfStatement') {
                     count++;
                     if (count > max) {
                         // Report error only for the violating `else-if`
@@ -35,6 +34,7 @@ module.exports = {
         docs: {
             description: 'Limit the number of consecutive else-if statements.',
             recommended: true,
+            url: 'https://github.com/andreasnicolaou/eslint-plugin-conditional-best-practices/blob/main/docs/no-long-else-if-chains.md',
         },
         messages: {
             maxElseIf: 'Avoid using more than {{max}} consecutive else-if statements.',

--- a/lib/rules/no-long-else-if-chains.js
+++ b/lib/rules/no-long-else-if-chains.js
@@ -6,6 +6,11 @@
 module.exports = {
     create: (context) => ({
         IfStatement(node) {
+            // Only evaluate from the head of a chain; nested `else if` nodes are
+            // the `alternate` of their parent and would re-report the same violation.
+            if (node.parent && node.parent.type === 'IfStatement' && node.parent.alternate === node) {
+                return;
+            }
             const options = context.options[0] || {};
             const max = options.max ?? 3;
             const checkElseIfDepth = (node) => {

--- a/lib/rules/no-nested-ternary-operators.js
+++ b/lib/rules/no-nested-ternary-operators.js
@@ -3,13 +3,12 @@
  * @author Andreas Nicolaou
  */
 'use strict';
-const utils = require('@typescript-eslint/utils');
 module.exports = {
     create: (context) => ({
         ConditionalExpression(node) {
             if (
-                (node.consequent && node.consequent.type === utils.AST_NODE_TYPES.ConditionalExpression) ||
-                (node.alternate && node.alternate.type === utils.AST_NODE_TYPES.ConditionalExpression)
+                (node.consequent && node.consequent.type === 'ConditionalExpression') ||
+                (node.alternate && node.alternate.type === 'ConditionalExpression')
             ) {
                 context.report({
                     node,
@@ -23,6 +22,7 @@ module.exports = {
         docs: {
             description: 'Enforce no nested ternary operators',
             recommended: true,
+            url: 'https://github.com/andreasnicolaou/eslint-plugin-conditional-best-practices/blob/main/docs/no-nested-ternary-operators.md',
         },
         messages: {
             nestedTernary:

--- a/lib/rules/no-useless-ternary.js
+++ b/lib/rules/no-useless-ternary.js
@@ -3,31 +3,48 @@
  * @author Andreas Nicolaou
  */
 'use strict';
-const utils = require('@typescript-eslint/utils');
+
+// Expression types that are tight enough in precedence to safely negate
+// with a leading `!` without needing wrapping parentheses.
+const SIMPLE_FOR_NEGATION = new Set(['Identifier', 'MemberExpression', 'CallExpression', 'Literal', 'UnaryExpression']);
+
 module.exports = {
     create: (context) => ({
         ConditionalExpression(node) {
-            const { consequent, alternate } = node;
-            // Check if both consequent and alternate are literals (true/false)
+            const { test, consequent, alternate } = node;
+            // Check if both consequent and alternate are boolean literals (true/false)
             if (
-                consequent.type === utils.AST_NODE_TYPES.Literal &&
-                alternate.type === utils.AST_NODE_TYPES.Literal &&
+                consequent.type === 'Literal' &&
+                alternate.type === 'Literal' &&
                 typeof consequent.value === 'boolean' &&
                 typeof alternate.value === 'boolean' &&
                 consequent.value === !alternate.value
             ) {
+                const sourceCode = context.sourceCode;
                 context.report({
                     node,
                     messageId: 'uselessTernary',
+                    fix(fixer) {
+                        const testText = sourceCode.getText(test);
+                        // `cond ? true : false` -> `cond`
+                        if (consequent.value === true) {
+                            return fixer.replaceText(node, testText);
+                        }
+                        // `cond ? false : true` -> `!cond`
+                        const negated = SIMPLE_FOR_NEGATION.has(test.type) ? `!${testText}` : `!(${testText})`;
+                        return fixer.replaceText(node, negated);
+                    },
                 });
             }
         },
     }),
     meta: {
         type: 'suggestion',
+        fixable: 'code',
         docs: {
             description: 'Disallow unnecessary ternary expressions.',
             recommended: true,
+            url: 'https://github.com/andreasnicolaou/eslint-plugin-conditional-best-practices/blob/main/docs/no-useless-ternary.md',
         },
         messages: {
             uselessTernary: 'This ternary is unnecessary; consider simplifying it.',

--- a/lib/rules/no-useless-ternary.js
+++ b/lib/rules/no-useless-ternary.js
@@ -20,7 +20,7 @@ module.exports = {
                 typeof alternate.value === 'boolean' &&
                 consequent.value === !alternate.value
             ) {
-                const sourceCode = context.sourceCode;
+                const sourceCode = context.sourceCode || context.getSourceCode();
                 context.report({
                     node,
                     messageId: 'uselessTernary',

--- a/lib/rules/prefer-early-return.js
+++ b/lib/rules/prefer-early-return.js
@@ -7,13 +7,17 @@ module.exports = {
     create: (context) => ({
         IfStatement(node) {
             if (!node.alternate) return; // Only check when there's an else block
-            if (
-                node.alternate.type === 'BlockStatement' &&
-                node.alternate.body.length === 1 &&
-                node.alternate.body[0].type === 'ReturnStatement'
-            ) {
+            const alternate = node.alternate;
+            // `else return;`
+            const isBareReturn = alternate.type === 'ReturnStatement';
+            // `else { return; }`
+            const isBlockWithReturn =
+                alternate.type === 'BlockStatement' &&
+                alternate.body.length === 1 &&
+                alternate.body[0].type === 'ReturnStatement';
+            if (isBareReturn || isBlockWithReturn) {
                 context.report({
-                    node: node.alternate,
+                    node: alternate,
                     messageId: 'earlyReturn',
                 });
             }

--- a/lib/rules/prefer-early-return.js
+++ b/lib/rules/prefer-early-return.js
@@ -3,15 +3,14 @@
  * @author Andreas Nicolaou
  */
 'use strict';
-const utils = require('@typescript-eslint/utils');
 module.exports = {
     create: (context) => ({
         IfStatement(node) {
             if (!node.alternate) return; // Only check when there's an else block
             if (
-                node.alternate.type === utils.AST_NODE_TYPES.BlockStatement &&
+                node.alternate.type === 'BlockStatement' &&
                 node.alternate.body.length === 1 &&
-                node.alternate.body[0].type === utils.AST_NODE_TYPES.ReturnStatement
+                node.alternate.body[0].type === 'ReturnStatement'
             ) {
                 context.report({
                     node: node.alternate,
@@ -25,6 +24,7 @@ module.exports = {
         docs: {
             description: 'Prefer early return instead of deep if-else nesting.',
             recommended: true,
+            url: 'https://github.com/andreasnicolaou/eslint-plugin-conditional-best-practices/blob/main/docs/prefer-early-return.md',
         },
         messages: {
             earlyReturn: 'Consider using an early return instead of nested if-else.',

--- a/lib/rules/require-default-in-switch.js
+++ b/lib/rules/require-default-in-switch.js
@@ -15,7 +15,8 @@ module.exports = {
                         {
                             messageId: 'addDefault',
                             fix(fixer) {
-                                const closingBrace = context.sourceCode.getLastToken(node);
+                                const sourceCode = context.sourceCode || context.getSourceCode();
+                                const closingBrace = sourceCode.getLastToken(node);
                                 return fixer.insertTextBefore(closingBrace, 'default: break; ');
                             },
                         },

--- a/lib/rules/require-default-in-switch.js
+++ b/lib/rules/require-default-in-switch.js
@@ -11,6 +11,15 @@ module.exports = {
                 context.report({
                     node,
                     messageId: 'missing',
+                    suggest: [
+                        {
+                            messageId: 'addDefault',
+                            fix(fixer) {
+                                const closingBrace = context.sourceCode.getLastToken(node);
+                                return fixer.insertTextBefore(closingBrace, 'default: break; ');
+                            },
+                        },
+                    ],
                 });
                 return;
             }
@@ -26,13 +35,16 @@ module.exports = {
     }),
     meta: {
         type: 'suggestion',
+        hasSuggestions: true,
         docs: {
             description: 'Ensure switch statements have a default case.',
             recommended: true,
+            url: 'https://github.com/andreasnicolaou/eslint-plugin-conditional-best-practices/blob/main/docs/require-default-in-switch.md',
         },
         messages: {
             missing: 'Switch statement should have a default case.',
             empty: 'Default case should not be empty.',
+            addDefault: 'Add a default case.',
         },
         schema: [],
     },

--- a/lib/tests/index.test.js
+++ b/lib/tests/index.test.js
@@ -1,0 +1,49 @@
+const assert = require('assert');
+const plugin = require(`${process.cwd()}/index`);
+
+describe('plugin index', () => {
+    it('exposes plugin meta (name and version) for flat config', () => {
+        assert.ok(plugin.meta, 'meta should be defined');
+        assert.strictEqual(typeof plugin.meta.name, 'string');
+        assert.strictEqual(typeof plugin.meta.version, 'string');
+    });
+
+    it('exports all rules with valid meta and a create function', () => {
+        const ruleNames = Object.keys(plugin.rules);
+        assert.ok(ruleNames.length > 0, 'should export at least one rule');
+        for (const name of ruleNames) {
+            const rule = plugin.rules[name];
+            assert.strictEqual(typeof rule.create, 'function', `${name} should have a create function`);
+            assert.ok(rule.meta, `${name} should have meta`);
+            assert.ok(rule.meta.docs && rule.meta.docs.url, `${name} should have a docs url`);
+            assert.ok(rule.meta.messages, `${name} should have messages`);
+        }
+    });
+
+    it('provides a flat recommended config that registers the plugin', () => {
+        const config = plugin.configs.recommended;
+        assert.ok(config, 'recommended config should exist');
+        assert.ok(config.plugins, 'flat recommended config should declare plugins');
+        assert.ok(
+            config.plugins['@andreasnicolaou/conditional-best-practices'],
+            'recommended config should register the plugin object'
+        );
+        assert.ok(Object.keys(config.rules).length > 0, 'recommended config should enable rules');
+    });
+
+    it('provides a flat "all" config enabling every rule', () => {
+        const config = plugin.configs.all;
+        assert.ok(config, 'all config should exist');
+        assert.strictEqual(
+            Object.keys(config.rules).length,
+            Object.keys(plugin.rules).length,
+            'all config should enable every rule'
+        );
+    });
+
+    it('provides a legacy-recommended config for eslintrc users', () => {
+        const config = plugin.configs['legacy-recommended'];
+        assert.ok(config, 'legacy-recommended config should exist');
+        assert.ok(Array.isArray(config.plugins), 'legacy config should declare plugins as an array');
+    });
+});

--- a/lib/tests/no-duplicated-conditions.test.js
+++ b/lib/tests/no-duplicated-conditions.test.js
@@ -3,10 +3,18 @@ const { RuleTester } = require('eslint');
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-duplicated-conditions', noDuplicatedConditions, {
-    valid: ['if (a) {} else if (b) {}'],
+    valid: ['if (a) {} else if (b) {}', 'if (a > b) {} else if (a < b) {}', 'if (x === 1) {} else if (x === 2) {}'],
     invalid: [
         {
             code: 'if (a) {} else if (a) {}',
+            errors: [{ messageId: 'duplicate' }],
+        },
+        {
+            code: 'if (a > b) {} else if (a > b) {}',
+            errors: [{ messageId: 'duplicate' }],
+        },
+        {
+            code: 'if (x === 1) {} else if (y) {} else if (x === 1) {}',
             errors: [{ messageId: 'duplicate' }],
         },
     ],

--- a/lib/tests/no-eval.test.js
+++ b/lib/tests/no-eval.test.js
@@ -41,5 +41,17 @@ ruleTester.run('no-eval', noEval, {
             code: 'const fn = new Function("return 1");',
             errors: [{ messageId: 'noFunction' }],
         },
+        {
+            code: 'eval.call(null, "1 + 1");',
+            errors: [{ messageId: 'noEval' }],
+        },
+        {
+            code: 'eval.apply(null, ["1 + 1"]);',
+            errors: [{ messageId: 'noEval' }],
+        },
+        {
+            code: '(0, eval)("1 + 1");',
+            errors: [{ messageId: 'noEval' }],
+        },
     ],
 });

--- a/lib/tests/no-eval.test.js
+++ b/lib/tests/no-eval.test.js
@@ -3,7 +3,15 @@ const { RuleTester } = require('eslint');
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-eval', noEval, {
-    valid: [],
+    valid: [
+        // Strings that merely contain the substring "eval" must NOT be flagged.
+        'const url = "https://example.com/retrieval";',
+        'const msg = "evaluation complete";',
+        'const word = "medieval";',
+        'const obj = { eval: 1 }; const v = obj.eval;',
+        'function evaluate() {} evaluate();',
+        'const x = foo.eval;',
+    ],
     invalid: [
         {
             code: 'eval(\'console.log("Hi")\');',
@@ -18,12 +26,20 @@ ruleTester.run('no-eval', noEval, {
             errors: [{ messageId: 'noEval' }],
         },
         {
+            code: 'window.eval("1 + 1");',
+            errors: [{ messageId: 'noEval' }],
+        },
+        {
             code: 'const exec = eval; exec(\'console.log("Not Allowed")\');',
             errors: [{ messageId: 'noEval' }],
         },
         {
             code: 'const safeEval = eval; safeEval(\'console.log("Allowed")\');',
             errors: [{ messageId: 'noEval' }],
+        },
+        {
+            code: 'const fn = new Function("return 1");',
+            errors: [{ messageId: 'noFunction' }],
         },
     ],
 });

--- a/lib/tests/no-long-else-if-chains.test.js
+++ b/lib/tests/no-long-else-if-chains.test.js
@@ -35,15 +35,30 @@ ruleTester.run('no-long-else-if-chains', noLongElseIfChains, {
         },
         {
             code: `
-                  if (a) {} 
-                  else if (b) {} 
-                  else if (c) {} 
-                  else if (d) {} 
+                  if (a) {}
+                  else if (b) {}
+                  else if (c) {}
+                  else if (d) {}
                   else if (e) {}
                   else if (f) {}
               `,
             options: [{ max: 4 }],
             errors: [{ messageId: 'maxElseIf', line: 7, column: 24 }],
+        },
+        {
+            // A chain far longer than `max` must report exactly once (no
+            // duplicate reports from each nested else-if node).
+            code: `
+                  if (a) {}
+                  else if (b) {}
+                  else if (c) {}
+                  else if (d) {}
+                  else if (e) {}
+                  else if (f) {}
+                  else if (g) {}
+              `,
+            options: [{ max: 2 }],
+            errors: [{ messageId: 'maxElseIf', line: 5, column: 24 }],
         },
     ],
 });

--- a/lib/tests/no-useless-ternary.test.js
+++ b/lib/tests/no-useless-ternary.test.js
@@ -3,14 +3,31 @@ const { RuleTester } = require('eslint');
 const ruleTester = new RuleTester();
 
 ruleTester.run('no-useless-ternary', noUselessTernary, {
-    valid: ['const isEnabled = condition1 ? "yes" : "no";'],
+    valid: [
+        'const isEnabled = condition1 ? "yes" : "no";',
+        'const x = a ? 1 : 0;',
+        'const y = a ? true : someValue;',
+        'const z = a ? b : false;',
+    ],
     invalid: [
         {
             code: 'const isActive = condition2 ? true : false;',
+            output: 'const isActive = condition2;',
             errors: [{ messageId: 'uselessTernary' }],
         },
         {
             code: 'const isInactive = condition3 ? false : true;',
+            output: 'const isInactive = !condition3;',
+            errors: [{ messageId: 'uselessTernary' }],
+        },
+        {
+            code: 'const isReady = a && b ? false : true;',
+            output: 'const isReady = !(a && b);',
+            errors: [{ messageId: 'uselessTernary' }],
+        },
+        {
+            code: 'const ok = isValid() ? true : false;',
+            output: 'const ok = isValid();',
             errors: [{ messageId: 'uselessTernary' }],
         },
     ],

--- a/lib/tests/prefer-early-return.test.js
+++ b/lib/tests/prefer-early-return.test.js
@@ -8,10 +8,14 @@ ruleTester.run('prefer-early-return', preferEarlyReturn, {
         {
             code: `
                 function check(x) {
-                    if (x) { helloWorld(); } 
+                    if (x) { helloWorld(); }
                     else { return; }
                     }
                 `,
+            errors: [{ messageId: 'earlyReturn' }],
+        },
+        {
+            code: 'function check(x) { if (x) { helloWorld(); } else return; }',
             errors: [{ messageId: 'earlyReturn' }],
         },
     ],

--- a/lib/tests/require-default-in-switch.test.js
+++ b/lib/tests/require-default-in-switch.test.js
@@ -7,7 +7,17 @@ ruleTester.run('require-default-in-switch', requireDefaultInSwitch, {
     invalid: [
         {
             code: 'switch (x) { case 1: break; case 2: break; }',
-            errors: [{ messageId: 'missing' }],
+            errors: [
+                {
+                    messageId: 'missing',
+                    suggestions: [
+                        {
+                            messageId: 'addDefault',
+                            output: 'switch (x) { case 1: break; case 2: break; default: break; }',
+                        },
+                    ],
+                },
+            ],
         },
         {
             code: 'switch (x) { case 1: break; case 2: break; default: }',

--- a/package.json
+++ b/package.json
@@ -1,24 +1,39 @@
 {
     "name": "@andreasnicolaou/eslint-plugin-conditional-best-practices",
-    "version": "1.2.0",
-    "description": "ESLint plugin to disallow excessive nested conditionals to improve readability",
+    "version": "2.0.0",
+    "description": "ESLint plugin with opinionated rules for cleaner, safer conditionals: limit nesting, prefer early returns, catch duplicate/constant conditions, and more.",
     "main": "index.js",
+    "type": "commonjs",
     "private": false,
     "scripts": {
         "test": "mocha lib/tests/*.test.js",
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",
         "format": "prettier --write .",
-        "test:bundle": "npx bundlewatch"
+        "test:bundle": "npx bundlewatch",
+        "prepublishOnly": "npm run lint && npm test"
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/andreasnicolaou/eslint-plugin-conditional-best-practices"
+        "url": "git+https://github.com/andreasnicolaou/eslint-plugin-conditional-best-practices.git"
+    },
+    "homepage": "https://github.com/andreasnicolaou/eslint-plugin-conditional-best-practices#readme",
+    "bugs": {
+        "url": "https://github.com/andreasnicolaou/eslint-plugin-conditional-best-practices/issues"
     },
     "author": "Andreas Nicolaou anicolaou66@gmail.com",
     "license": "MIT",
+    "engines": {
+        "node": ">=18"
+    },
+    "files": [
+        "index.js",
+        "lib/rules",
+        "README.md",
+        "LICENSE"
+    ],
     "peerDependencies": {
-        "eslint": ">=9.39.0"
+        "eslint": ">=8"
     },
     "bundlewatch": {
         "files": [
@@ -43,12 +58,19 @@
     },
     "keywords": [
         "eslint",
+        "eslintplugin",
         "eslint-plugin",
+        "eslint-plugin-conditional-best-practices",
+        "flat-config",
         "conditionals",
-        "best practises",
-        "no-excessive-nested-conditionals"
-    ],
-    "dependencies": {
-        "@typescript-eslint/utils": "^8.61.1"
-    }
+        "best-practices",
+        "code-quality",
+        "lint",
+        "ternary",
+        "no-nested-ternary",
+        "early-return",
+        "switch-default",
+        "no-excessive-nested-conditionals",
+        "no-eval"
+    ]
 }


### PR DESCRIPTION
BREAKING CHANGE: configs.recommended is now an ESLint flat config object (with a `plugins` key) instead of the legacy eslintrc `{ rules }` shape. Legacy eslintrc users should switch to configs['legacy-recommended'].

- Fix no-eval: stop flagging any string containing the substring "eval" (e.g. "retrieval", "evaluation"); detect real risks only — eval(), aliased eval, window/globalThis/self/global.eval, and new Function()
- Add proper flat-config support: plugin meta (name/version) and recommended/all/legacy-recommended configs; verified via the ESLint API
- Remove @typescript-eslint/utils runtime dep (used only for AST type string constants) — plugin now has zero runtime dependencies
- Add autofix to no-useless-ternary (cond ? true : false -> cond) and a suggestion to require-default-in-switch to insert a default case
- Broaden no-duplicated-conditions to catch any repeated condition
- Add meta.docs.url and fixable/hasSuggestions to every rule
- CI now runs lint; add prepublishOnly lint+test gate